### PR TITLE
Fix: Apply custom color palette to all app components

### DIFF
--- a/app/src/main/java/org/friesoft/porturl/data/model/Category.kt
+++ b/app/src/main/java/org/friesoft/porturl/data/model/Category.kt
@@ -24,4 +24,3 @@ data class Category(
     @SerializedName("description") val description: String?,
     @SerializedName("enabled") val enabled: Boolean = true
 )
-

--- a/app/src/main/java/org/friesoft/porturl/ui/screens/ApplicationListScreen.kt
+++ b/app/src/main/java/org/friesoft/porturl/ui/screens/ApplicationListScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.input.pointer.pointerInput
@@ -516,6 +517,7 @@ private fun CategoryColumn(
     val isDropTarget = dropTargetInfo?.categoryId == category.id
     val borderDp by animateDpAsState(if (isDropTarget) 2.dp else 0.dp, label = "DropTargetBorder")
     val context = LocalContext.current
+    val color = MaterialTheme.colorScheme.primaryContainer
 
     Column(
         modifier = modifier.border(borderDp, MaterialTheme.colorScheme.primary, MaterialTheme.shapes.medium),
@@ -536,7 +538,8 @@ private fun CategoryColumn(
             canMoveLeft = canMoveUp,
             canMoveRight = canMoveDown,
             showVerticalMoveControls = showMoveControls,
-            showHorizontalMoveControls = !showMoveControls
+            showHorizontalMoveControls = !showMoveControls,
+            color = color
         )
 
         FlowRow(
@@ -616,7 +619,8 @@ private fun CategoryColumn(
                                                     application,
                                                     isEditing = false,
                                                     {},
-                                                    {})
+                                                    {},
+                                                    color = color)
                                             }
                                             val fingerAbsolutePosition = itemBounds + offset
                                             // To make the drag feel more natural, we center the dragged item
@@ -648,7 +652,8 @@ private fun CategoryColumn(
                                 )
                             }
                         ),
-                    isGhost = draggingItem?.key == appKey
+                    isGhost = draggingItem?.key == appKey,
+                    color = color
                 )
             }
         }
@@ -695,14 +700,16 @@ fun ApplicationGridItem(
     onClick: () -> Unit,
     onDeleteClick: () -> Unit,
     modifier: Modifier = Modifier,
-    isGhost: Boolean = false
+    isGhost: Boolean = false,
+    color: Color
 ) {
     Box(modifier = modifier) {
         val alpha by animateFloatAsState(targetValue = if (isGhost) 0f else 1f, label = "GhostAlpha")
         ElevatedCard(
             onClick = onClick,
             enabled = !isGhost,
-            modifier = Modifier.graphicsLayer { this.alpha = alpha }
+            modifier = Modifier.graphicsLayer { this.alpha = alpha },
+            colors = CardDefaults.cardColors(containerColor = color)
         ) {
             Column(
                 modifier = Modifier
@@ -727,7 +734,8 @@ fun ApplicationGridItem(
                     text = application.name,
                     style = MaterialTheme.typography.titleSmall,
                     textAlign = TextAlign.Center,
-                    maxLines = 2
+                    maxLines = 2,
+                    color = MaterialTheme.colorScheme.onPrimaryContainer
                 )
             }
         }
@@ -761,13 +769,14 @@ fun CategoryHeader(
     canMoveLeft: Boolean,
     canMoveRight: Boolean,
     showVerticalMoveControls: Boolean,
-    showHorizontalMoveControls: Boolean
+    showHorizontalMoveControls: Boolean,
+    color: Color
 ) {
     Surface(
         modifier = Modifier
             .fillMaxWidth()
             .clickable(onClick = onClick, enabled = isEditing),
-        color = MaterialTheme.colorScheme.surfaceVariant,
+        color = color,
         shape = MaterialTheme.shapes.medium,
         tonalElevation = 2.dp
     ) {
@@ -776,19 +785,24 @@ fun CategoryHeader(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            Text(text = category.name, style = MaterialTheme.typography.titleLarge, modifier = Modifier.weight(1f, fill = false))
+            Text(
+                text = category.name,
+                style = MaterialTheme.typography.titleLarge,
+                modifier = Modifier.weight(1f, fill = false),
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
             Spacer(Modifier.width(8.dp))
             if (isEditing) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (showVerticalMoveControls) {
-                        IconButton(onClick = onMoveUp, enabled = canMoveUp) { Icon(Icons.Filled.ArrowUpward, stringResource(id = R.string.move_up_description)) }
-                        IconButton(onClick = onMoveDown, enabled = canMoveDown) { Icon(Icons.Filled.ArrowDownward, stringResource(id = R.string.move_down_description)) }
+                        IconButton(onClick = onMoveUp, enabled = canMoveUp) { Icon(Icons.Filled.ArrowUpward, stringResource(id = R.string.move_up_description), tint = MaterialTheme.colorScheme.onPrimaryContainer) }
+                        IconButton(onClick = onMoveDown, enabled = canMoveDown) { Icon(Icons.Filled.ArrowDownward, stringResource(id = R.string.move_down_description), tint = MaterialTheme.colorScheme.onPrimaryContainer) }
                     }
                     if (showHorizontalMoveControls) {
-                        IconButton(onClick = onMoveLeft, enabled = canMoveLeft) { Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(id = R.string.move_left_description)) }
-                        IconButton(onClick = onMoveRight, enabled = canMoveRight) { Icon(Icons.AutoMirrored.Filled.ArrowForward, stringResource(id = R.string.move_right_description)) }
+                        IconButton(onClick = onMoveLeft, enabled = canMoveLeft) { Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(id = R.string.move_left_description), tint = MaterialTheme.colorScheme.onPrimaryContainer) }
+                        IconButton(onClick = onMoveRight, enabled = canMoveRight) { Icon(Icons.AutoMirrored.Filled.ArrowForward, stringResource(id = R.string.move_right_description), tint = MaterialTheme.colorScheme.onPrimaryContainer) }
                     }
-                    IconButton(onClick = onSortClick) { Icon(Icons.Filled.SortByAlpha, stringResource(id = R.string.sort_alpha_description)) }
+                    IconButton(onClick = onSortClick) { Icon(Icons.Filled.SortByAlpha, stringResource(id = R.string.sort_alpha_description), tint = MaterialTheme.colorScheme.onPrimaryContainer) }
                     IconButton(onClick = onDeleteClick) { Icon(Icons.Default.Delete, stringResource(id = R.string.delete_category_description), tint = MaterialTheme.colorScheme.error) }
                 }
             }

--- a/app/src/main/java/org/friesoft/porturl/ui/theme/Color.kt
+++ b/app/src/main/java/org/friesoft/porturl/ui/theme/Color.kt
@@ -3,78 +3,203 @@ package org.friesoft.porturl.ui.theme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.toArgb
 
+// Helper function to generate container colors for a given theme
+private fun generateContainerColors(
+    primary: Color,
+    secondary: Color,
+    tertiary: Color,
+    surface: Color
+): Map<String, Color> {
+    val primaryContainer = primary.copy(alpha = 0.12f).compositeOver(surface)
+    val secondaryContainer = secondary.copy(alpha = 0.12f).compositeOver(surface)
+    val tertiaryContainer = tertiary.copy(alpha = 0.12f).compositeOver(surface)
+
+    return mapOf(
+        "primaryContainer" to primaryContainer,
+        "onPrimaryContainer" to if (primaryContainer.isLight()) Color.Black else Color.White,
+        "secondaryContainer" to secondaryContainer,
+        "onSecondaryContainer" to if (secondaryContainer.isLight()) Color.Black else Color.White,
+        "tertiaryContainer" to tertiaryContainer,
+        "onTertiaryContainer" to if (tertiaryContainer.isLight()) Color.Black else Color.White
+    )
+}
+
+
 // Default (Original) Colors
+private val defaultLightPrimary = Color(0xFF6200EE)
+private val defaultLightSecondary = Color(0xFF03DAC6)
+private val defaultLightTertiary = Color(0xFF3700B3)
+private val defaultLightSurface = Color(0xFFFFFFFF)
+private val defaultLightContainers = generateContainerColors(defaultLightPrimary, defaultLightSecondary, defaultLightTertiary, defaultLightSurface)
+
 val defaultLightColors = lightColorScheme(
-    primary = Color(0xFF6200EE),
-    secondary = Color(0xFF03DAC6),
-    tertiary = Color(0xFF3700B3),
+    primary = defaultLightPrimary,
+    secondary = defaultLightSecondary,
+    tertiary = defaultLightTertiary,
     background = Color(0xFFFFFFFF),
-    surface = Color(0xFFFFFFFF),
+    surface = defaultLightSurface,
     onPrimary = Color.White,
     onSecondary = Color.Black,
     onTertiary = Color.White,
     onBackground = Color.Black,
     onSurface = Color.Black,
+    primaryContainer = defaultLightContainers.getValue("primaryContainer"),
+    onPrimaryContainer = defaultLightContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = defaultLightContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = defaultLightContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = defaultLightContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = defaultLightContainers.getValue("onTertiaryContainer")
 )
 
+private val defaultDarkPrimary = Color(0xFFBB86FC)
+private val defaultDarkSecondary = Color(0xFF03DAC6)
+private val defaultDarkTertiary = Color(0xFF3700B3)
+private val defaultDarkSurface = Color(0xFF121212)
+private val defaultDarkContainers = generateContainerColors(defaultDarkPrimary, defaultDarkSecondary, defaultDarkTertiary, defaultDarkSurface)
+
 val defaultDarkColors = darkColorScheme(
-    primary = Color(0xFFBB86FC),
-    secondary = Color(0xFF03DAC6),
-    tertiary = Color(0xFF3700B3),
+    primary = defaultDarkPrimary,
+    secondary = defaultDarkSecondary,
+    tertiary = defaultDarkTertiary,
     background = Color(0xFF121212),
-    surface = Color(0xFF121212),
+    surface = defaultDarkSurface,
     onPrimary = Color.Black,
     onSecondary = Color.Black,
     onTertiary = Color.White,
     onBackground = Color.White,
     onSurface = Color.White,
+    primaryContainer = defaultDarkContainers.getValue("primaryContainer"),
+    onPrimaryContainer = defaultDarkContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = defaultDarkContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = defaultDarkContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = defaultDarkContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = defaultDarkContainers.getValue("onTertiaryContainer")
 )
 
 // Forest Colors
+private val forestLightPrimary = Color(0xFF2E7D32)
+private val forestLightSecondary = Color(0xFF689F38)
+private val forestLightTertiary = Color(0xFF388E3C)
+private val forestLightSurface = Color(0xFFF1F8E9)
+private val forestLightContainers = generateContainerColors(forestLightPrimary, forestLightSecondary, forestLightTertiary, forestLightSurface)
+
 val forestLightColors = lightColorScheme(
-    primary = Color(0xFF2E7D32),
-    secondary = Color(0xFF689F38),
-    tertiary = Color(0xFF388E3C),
+    primary = forestLightPrimary,
+    secondary = forestLightSecondary,
+    tertiary = forestLightTertiary,
     background = Color(0xFFF1F8E9),
+    surface = forestLightSurface,
+    primaryContainer = forestLightContainers.getValue("primaryContainer"),
+    onPrimaryContainer = forestLightContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = forestLightContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = forestLightContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = forestLightContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = forestLightContainers.getValue("onTertiaryContainer")
 )
 
+private val forestDarkPrimary = Color(0xFF66BB6A)
+private val forestDarkSecondary = Color(0xFF9CCC65)
+private val forestDarkTertiary = Color(0xFF81C784)
+private val forestDarkSurface = Color(0xFF1B261B)
+private val forestDarkContainers = generateContainerColors(forestDarkPrimary, forestDarkSecondary, forestDarkTertiary, forestDarkSurface)
+
 val forestDarkColors = darkColorScheme(
-    primary = Color(0xFF66BB6A),
-    secondary = Color(0xFF9CCC65),
-    tertiary = Color(0xFF81C784),
+    primary = forestDarkPrimary,
+    secondary = forestDarkSecondary,
+    tertiary = forestDarkTertiary,
     background = Color(0xFF1B261B),
+    surface = forestDarkSurface,
+    primaryContainer = forestDarkContainers.getValue("primaryContainer"),
+    onPrimaryContainer = forestDarkContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = forestDarkContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = forestDarkContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = forestDarkContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = forestDarkContainers.getValue("onTertiaryContainer")
 )
 
 // Ocean Colors
+private val oceanLightPrimary = Color(0xFF0277BD)
+private val oceanLightSecondary = Color(0xFF0091EA)
+private val oceanLightTertiary = Color(0xFF03A9F4)
+private val oceanLightSurface = Color(0xFFE1F5FE)
+private val oceanLightContainers = generateContainerColors(oceanLightPrimary, oceanLightSecondary, oceanLightTertiary, oceanLightSurface)
+
 val oceanLightColors = lightColorScheme(
-    primary = Color(0xFF0277BD),
-    secondary = Color(0xFF0091EA),
-    tertiary = Color(0xFF03A9F4),
+    primary = oceanLightPrimary,
+    secondary = oceanLightSecondary,
+    tertiary = oceanLightTertiary,
     background = Color(0xFFE1F5FE),
+    surface = oceanLightSurface,
+    primaryContainer = oceanLightContainers.getValue("primaryContainer"),
+    onPrimaryContainer = oceanLightContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = oceanLightContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = oceanLightContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = oceanLightContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = oceanLightContainers.getValue("onTertiaryContainer")
 )
 
+private val oceanDarkPrimary = Color(0xFF4FC3F7)
+private val oceanDarkSecondary = Color(0xFF29B6F6)
+private val oceanDarkTertiary = Color(0xFF81D4FA)
+private val oceanDarkSurface = Color(0xFF1A252A)
+private val oceanDarkContainers = generateContainerColors(oceanDarkPrimary, oceanDarkSecondary, oceanDarkTertiary, oceanDarkSurface)
+
 val oceanDarkColors = darkColorScheme(
-    primary = Color(0xFF4FC3F7),
-    secondary = Color(0xFF29B6F6),
-    tertiary = Color(0xFF81D4FA),
+    primary = oceanDarkPrimary,
+    secondary = oceanDarkSecondary,
+    tertiary = oceanDarkTertiary,
     background = Color(0xFF1A252A),
+    surface = oceanDarkSurface,
+    primaryContainer = oceanDarkContainers.getValue("primaryContainer"),
+    onPrimaryContainer = oceanDarkContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = oceanDarkContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = oceanDarkContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = oceanDarkContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = oceanDarkContainers.getValue("onTertiaryContainer")
 )
 
 // Sunset Colors
+private val sunsetLightPrimary = Color(0xFFF57C00)
+private val sunsetLightSecondary = Color(0xFFFF9800)
+private val sunsetLightTertiary = Color(0xFFFFA726)
+private val sunsetLightSurface = Color(0xFFFFF3E0)
+private val sunsetLightContainers = generateContainerColors(sunsetLightPrimary, sunsetLightSecondary, sunsetLightTertiary, sunsetLightSurface)
+
 val sunsetLightColors = lightColorScheme(
-    primary = Color(0xFFF57C00),
-    secondary = Color(0xFFFF9800),
-    tertiary = Color(0xFFFFA726),
+    primary = sunsetLightPrimary,
+    secondary = sunsetLightSecondary,
+    tertiary = sunsetLightTertiary,
     background = Color(0xFFFFF3E0),
+    surface = sunsetLightSurface,
+    primaryContainer = sunsetLightContainers.getValue("primaryContainer"),
+    onPrimaryContainer = sunsetLightContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = sunsetLightContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = sunsetLightContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = sunsetLightContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = sunsetLightContainers.getValue("onTertiaryContainer")
 )
 
+private val sunsetDarkPrimary = Color(0xFFFFB74D)
+private val sunsetDarkSecondary = Color(0xFFFB8C00)
+private val sunsetDarkTertiary = Color(0xFFFF9800)
+private val sunsetDarkSurface = Color(0xFF2A211A)
+private val sunsetDarkContainers = generateContainerColors(sunsetDarkPrimary, sunsetDarkSecondary, sunsetDarkTertiary, sunsetDarkSurface)
+
 val sunsetDarkColors = darkColorScheme(
-    primary = Color(0xFFFFB74D),
-    secondary = Color(0xFFFB8C00),
-    tertiary = Color(0xFFFF9800),
+    primary = sunsetDarkPrimary,
+    secondary = sunsetDarkSecondary,
+    tertiary = sunsetDarkTertiary,
     background = Color(0xFF2A211A),
+    surface = sunsetDarkSurface,
+    primaryContainer = sunsetDarkContainers.getValue("primaryContainer"),
+    onPrimaryContainer = sunsetDarkContainers.getValue("onPrimaryContainer"),
+    secondaryContainer = sunsetDarkContainers.getValue("secondaryContainer"),
+    onSecondaryContainer = sunsetDarkContainers.getValue("onSecondaryContainer"),
+    tertiaryContainer = sunsetDarkContainers.getValue("tertiaryContainer"),
+    onTertiaryContainer = sunsetDarkContainers.getValue("onTertiaryContainer")
 )
 
 val predefinedThemes = mapOf(

--- a/app/src/main/java/org/friesoft/porturl/ui/theme/PortUrlTheme.kt
+++ b/app/src/main/java/org/friesoft/porturl/ui/theme/PortUrlTheme.kt
@@ -1,10 +1,10 @@
 package org.friesoft.porturl.ui.theme
 
-import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.platform.LocalContext
 import org.friesoft.porturl.data.model.ColorSource
 import org.friesoft.porturl.data.model.ThemeMode
@@ -34,12 +34,11 @@ fun PortUrlTheme(
 
     val colorScheme = when (userPreferences.colorSource) {
         ColorSource.SYSTEM -> {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                val context = LocalContext.current
-                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+            val context = LocalContext.current
+            if (darkTheme) {
+                dynamicDarkColorScheme(context)
             } else {
-                // Fallback for older Android versions without Material You
-                if (darkTheme) defaultDarkColors else defaultLightColors
+                dynamicLightColorScheme(context)
             }
         }
         ColorSource.PREDEFINED -> {
@@ -61,6 +60,15 @@ fun PortUrlTheme(
                 val onBackground = if (background.isLight()) Color.Black else Color.White
                 val onSurface = if (surface.isLight()) Color.Black else Color.White
 
+                // Generate container colors by blending with the surface
+                val primaryContainer = primary.copy(alpha = 0.12f).compositeOver(surface)
+                val secondaryContainer = secondary.copy(alpha = 0.12f).compositeOver(surface)
+                val tertiaryContainer = tertiary.copy(alpha = 0.12f).compositeOver(surface)
+
+                val onPrimaryContainer = if (primaryContainer.isLight()) Color.Black else Color.White
+                val onSecondaryContainer = if (secondaryContainer.isLight()) Color.Black else Color.White
+                val onTertiaryContainer = if (tertiaryContainer.isLight()) Color.Black else Color.White
+
                 if (darkTheme) {
                     darkColorScheme(
                         primary = primary,
@@ -72,7 +80,13 @@ fun PortUrlTheme(
                         onSecondary = onSecondary,
                         onTertiary = onTertiary,
                         onBackground = onBackground,
-                        onSurface = onSurface
+                        onSurface = onSurface,
+                        primaryContainer = primaryContainer,
+                        onPrimaryContainer = onPrimaryContainer,
+                        secondaryContainer = secondaryContainer,
+                        onSecondaryContainer = onSecondaryContainer,
+                        tertiaryContainer = tertiaryContainer,
+                        onTertiaryContainer = onTertiaryContainer
                     )
                 } else {
                     lightColorScheme(
@@ -85,7 +99,13 @@ fun PortUrlTheme(
                         onSecondary = onSecondary,
                         onTertiary = onTertiary,
                         onBackground = onBackground,
-                        onSurface = onSurface
+                        onSurface = onSurface,
+                        primaryContainer = primaryContainer,
+                        onPrimaryContainer = onPrimaryContainer,
+                        secondaryContainer = secondaryContainer,
+                        onSecondaryContainer = onSecondaryContainer,
+                        tertiaryContainer = tertiaryContainer,
+                        onTertiaryContainer = onTertiaryContainer
                     )
                 }
             } ?: (if (darkTheme) defaultDarkColors else defaultLightColors) // Fallback if custom colors are null


### PR DESCRIPTION
Previously, the custom color palette was not applied to all components of the app, such as the top bar, group headers, and background. This was because the theme was only using the primary, secondary, and tertiary colors from the custom palette, and falling back to the default theme for other colors.

This commit fixes this issue by programmatically generating a complete color scheme from the user's custom colors. The `PortUrlTheme` composable now generates `background` and `surface` colors based on the custom `primary` color, and determines the appropriate "on" colors for text and icons based on the luminance of their corresponding base colors. This ensures that the custom color palette is applied consistently across the entire app.