### PR TITLE
feat: Add translucent background setting

### DIFF
--- a/app/src/main/java/org/friesoft/porturl/data/model/UserPreferences.kt
+++ b/app/src/main/java/org/friesoft/porturl/data/model/UserPreferences.kt
@@ -89,5 +89,6 @@ data class UserPreferences(
     val themeMode: ThemeMode,
     val colorSource: ColorSource,
     val predefinedColorName: String?,
-    val customColors: CustomColors?
+    val customColors: CustomColors?,
+    val translucentBackground: Boolean = false
 )

--- a/app/src/main/java/org/friesoft/porturl/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/org/friesoft/porturl/ui/screens/SettingsScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Switch
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -77,7 +78,13 @@ import org.friesoft.porturl.viewmodels.ValidationState
 @Composable
 fun SettingsScreen(navController: NavController, viewModel: SettingsViewModel = hiltViewModel()) {
     val userPreferences by viewModel.userPreferences.collectAsStateWithLifecycle(
-        initialValue = UserPreferences(ThemeMode.SYSTEM, ColorSource.SYSTEM, null, null)
+        initialValue = UserPreferences(
+            ThemeMode.SYSTEM,
+            ColorSource.SYSTEM,
+            null,
+            null,
+            translucentBackground = false
+        )
     )
     val snackbarHostState = remember { SnackbarHostState() }
     val validationState by viewModel.validationState.collectAsStateWithLifecycle()
@@ -124,7 +131,9 @@ fun SettingsScreen(navController: NavController, viewModel: SettingsViewModel = 
                 Spacer(modifier = Modifier.height(16.dp))
                 ThemeSettings(
                     selectedThemeMode = userPreferences.themeMode,
-                    onThemeModeSelected = { viewModel.saveThemeMode(it) }
+                    onThemeModeSelected = { viewModel.saveThemeMode(it) },
+                    translucentBackground = userPreferences.translucentBackground,
+                    onTranslucentBackgroundChange = { viewModel.saveTranslucentBackground(it) }
                 )
                 HorizontalDivider(
                     modifier = Modifier.padding(vertical = 16.dp),
@@ -168,7 +177,9 @@ private fun SectionTitle(title: String) {
 @Composable
 private fun ThemeSettings(
     selectedThemeMode: ThemeMode,
-    onThemeModeSelected: (ThemeMode) -> Unit
+    onThemeModeSelected: (ThemeMode) -> Unit,
+    translucentBackground: Boolean,
+    onTranslucentBackgroundChange: (Boolean) -> Unit
 ) {
     Column {
         SectionTitle(stringResource(id = R.string.settings_appearance_title))
@@ -192,6 +203,23 @@ private fun ThemeSettings(
                 }
                 Text(text = themeName)
             }
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onTranslucentBackgroundChange(!translucentBackground) }
+                .padding(vertical = 8.dp)
+        ) {
+            Text(
+                text = stringResource(id = R.string.settings_translucent_background_label),
+                modifier = Modifier.weight(1f)
+            )
+            Switch(
+                checked = translucentBackground,
+                onCheckedChange = onTranslucentBackgroundChange
+            )
         }
     }
 }

--- a/app/src/main/java/org/friesoft/porturl/viewmodels/SettingsViewModel.kt
+++ b/app/src/main/java/org/friesoft/porturl/viewmodels/SettingsViewModel.kt
@@ -126,6 +126,12 @@ class SettingsViewModel @Inject constructor(
             settingsRepository.saveCustomColors(customColors)
         }
     }
+
+    fun saveTranslucentBackground(translucent: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.saveTranslucentBackground(translucent)
+        }
+    }
 }
 
 data class SettingState(

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -101,5 +101,6 @@
     <string name="app_detail_categories_title">Kategorien (mindestens eine ist erforderlich)</string>
     <string name="app_detail_category_selected">Ausgewählt</string>
     <string name="app_detail_icon_description">Anwendungssymbol</string>
+    <string name="settings_translucent_background_label">Durchscheinender Anwendungshintergrund</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -101,5 +101,6 @@
     <string name="app_detail_categories_title">Categories (at least one is required)</string>
     <string name="app_detail_category_selected">Selected</string>
     <string name="app_detail_icon_description">Application Icon</string>
+    <string name="settings_translucent_background_label">Translucent Application Background</string>
 
 </resources>


### PR DESCRIPTION
Adds a new setting to allow users to make the background of application grid items translucent.

This includes:
- A new boolean preference in `UserPreferences`.
- A `Switch` in the settings screen to control the preference.
- Logic in `ApplicationGridItem` to apply a translucent background when the setting is enabled.
- German translations for the new setting.